### PR TITLE
Update API-design-guidelines - OAS version to be used by subprojects

### DIFF
--- a/Commonalities/documentation/API-design-guidelines.md
+++ b/Commonalities/documentation/API-design-guidelines.md
@@ -920,7 +920,7 @@ API documentation usually consists of:
 - Reference information to inform customers of every detail of your API.
 
 Below considerations should be checked when an API is documented:
-- The API functionalities must be implemented following the specifications of the Open API latest version using the .yaml or .json file extension.
+- The API functionalities must be implemented following the specifications of the [Open API version 3.0.3](https://spec.openapis.org/oas/v3.0.3) using the .yaml or .json file extension.
 - The API specification structure should have the following parts:
    -	General information ([Section 11.1](#111-general-information))
    -  Published Routes ([Section 11.2](#112-published-routes))


### PR DESCRIPTION
The clarification of version of OpenAPI specification to be used by subprojects

#### What type of PR is this?

* correction

#### What this PR does / why we need it:
 
The clarification of version of OpenAPI specification to be used by subprojects is needed.
The latest version of OAS is [3.1.0](https://spec.openapis.org/oas/latest.html) published on 15 February 2021. However, currently all subprojects use [3.0.3](https://spec.openapis.org/oas/v3.0.3) version of OAS, supported by majority of tools.


#### Which issue(s) this PR fixes:

Fixes #184


#### Changelog input

```
The version of  OpenAPI specification was set to 3.0.3 in API Design Guidelines.

```


