### PR TITLE
Move Versioning doc under main documentation 

### DIFF
--- a/Commonalities/documentation/Camara_Versioning_Guidelines.md
+++ b/Commonalities/documentation/Camara_Versioning_Guidelines.md
@@ -1,7 +1,7 @@
 # Camara subproject release guidelines
 
 * Release name for subprojects should be same as the tag-name for e.g. v0.8.0. The Github [release feature](https://docs.github.com/en/repositories/releasing-projects-on-github/managing-releases-in-a-repository) should be used for this purpose. If referenced outside the subproject, it can be referred to as Release **\<sub-project-name>\<tag-name>** for eg. Release QualityOnDemand v0.8.0
-* Every release includes the **CHANGELOG.md** file in the root directory of the subproject. Please make sure that the content is structured in a format that is easy to read. Please refer to the template provided here for possible sections that could be added to a changelog [CHANGELOG_TEMPLATE.md](./CHANGELOG_TEMPLATE.md). Every release would add to the changelog. An example of how a changelog could look over time is shown below.
+* Every release includes the **CHANGELOG.md** file in the root directory of the subproject. Please make sure that the content is structured in a format that is easy to read. Please refer to the template provided here for possible sections that could be added to a changelog [CHANGELOG_TEMPLATE.md](https://github.com/camaraproject/WorkingGroups/blob/main/Commonalities/documentation/SupportingDocuments/CHANGELOG_TEMPLATE.md). Every release would add to the changelog. An example of how a changelog could look over time is shown below.
 * The release can be agreed within the subproject by making a pull request for the changelog. The merge of this pull request would be marked as the release commit and the text within the changelog would be used as the release description
 * Changelog content:
     * APIs/Software in alpha release needs to be clearly specified

--- a/Commonalities/documentation/SupportingDocuments/CHANGELOG_TEMPLATE.md
+++ b/Commonalities/documentation/SupportingDocuments/CHANGELOG_TEMPLATE.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## X.Y.Z [ALPHA] - YYYY-MM-DD
+## X.Y.Z [ALPHA]
 
 ### Added
 


### PR DESCRIPTION
Fixes #228 
Removed date from the name of Changelog name to address https://github.com/camaraproject/WorkingGroups/issues/208#issuecomment-1547446293