### PR TITLE
Update README.MD to update documentation links pointing to new repo

### DIFF
--- a/Commonalities/README.MD
+++ b/Commonalities/README.MD
@@ -1,6 +1,6 @@
 ## Scope
 * Elaborate and list “Commonalities for APIs”, work out commonalities on the list
-* Commonalities are topics which apply to some or all APIs, e.g. authentification, authorization, API documentation and development standards, ...
+* Commonalities are topics which apply to some or all APIs, e.g. API design guidelines, API readiness criteria checklist, Glossary etc.
 * Started: October 2021  
 * Location: virtually  
 
@@ -13,8 +13,9 @@
 ## Results
 Documentation includes:
 * Meeting minutes : [MeetingMinutes](https://github.com/camaraproject/WorkingGroups/tree/main/Commonalities/documentation/MeetingMinutes)
-* Presentations and other supplementary docs : [SupportingDocuments](https://github.com/camaraproject/WorkingGroups/tree/main/Commonalities/documentation/SupportingDocuments)
-* Commonalities approved deliverables: [documentation](https://github.com/camaraproject/WorkingGroups/tree/main/Commonalities/documentation)
+* Presentations and other supplementary docs : [SupportingDocuments](https://github.com/camaraproject/Commonalities/tree/main/documentation/SupportingDocuments)
+* Commonalities approved deliverables: [Documentation](https://github.com/camaraproject/Commonalities/tree/main/documentation)
+* Commonalities approved artifacts:  [Artifacts](https://github.com/camaraproject/Commonalities/tree/main/artifacts)
 
 ## Mailing list
 * To subscribe / unsubscribe to the mailing list of this Working Group please visit <https://lists.camaraproject.org/g/wg-com>.

--- a/Commonalities/README.MD
+++ b/Commonalities/README.MD
@@ -12,7 +12,7 @@
 
 ## Results
 Documentation includes:
-* Meeting minutes : [MeetingMinutes](https://github.com/camaraproject/WorkingGroups/tree/main/Commonalities/documentation/MeetingMinutes)
+* Meeting minutes : [MeetingMinutes](https://github.com/camaraproject/Commonalities/tree/main/documentation/MeetingMinutes)
 * Presentations and other supplementary docs : [SupportingDocuments](https://github.com/camaraproject/Commonalities/tree/main/documentation/SupportingDocuments)
 * Commonalities approved deliverables: [Documentation](https://github.com/camaraproject/Commonalities/tree/main/documentation)
 * Commonalities approved artifacts:  [Artifacts](https://github.com/camaraproject/Commonalities/tree/main/artifacts)

--- a/Commonalities/documentation/README.md
+++ b/Commonalities/documentation/README.md
@@ -4,7 +4,7 @@ We have moved to https://github.com/camaraproject/Commonalities
 **Please open all new issues and PRs for commonalities in the new repo. All existing open issues have already been moved to the new repo.**
 
 Relevant links:
-* Meeting minutes : [MeetingMinutes](https://github.com/camaraproject/WorkingGroups/tree/main/Commonalities/documentation/MeetingMinutes)
+* Meeting minutes : [MeetingMinutes](https://github.com/camaraproject/Commonalities/tree/main/documentation/MeetingMinutes)
 * Presentations and other supplementary docs : [SupportingDocuments](https://github.com/camaraproject/Commonalities/tree/main/documentation/SupportingDocuments)
 * Commonalities approved deliverables: [Documentation](https://github.com/camaraproject/Commonalities/tree/main/documentation)
 * Commonalities approved artifacts:  [Artifacts](https://github.com/camaraproject/Commonalities/tree/main/artifacts)

--- a/Commonalities/documentation/README.md
+++ b/Commonalities/documentation/README.md
@@ -1,0 +1,2 @@
+# Commonalities documentation and artifacts
+We have moved to https://github.com/camaraproject/Commonalities

--- a/Commonalities/documentation/README.md
+++ b/Commonalities/documentation/README.md
@@ -1,2 +1,8 @@
 # Commonalities documentation and artifacts
 We have moved to https://github.com/camaraproject/Commonalities
+
+Relevant links:
+* Meeting minutes : [MeetingMinutes](https://github.com/camaraproject/WorkingGroups/tree/main/Commonalities/documentation/MeetingMinutes)
+* Presentations and other supplementary docs : [SupportingDocuments](https://github.com/camaraproject/Commonalities/tree/main/documentation/SupportingDocuments)
+* Commonalities approved deliverables: [Documentation](https://github.com/camaraproject/Commonalities/tree/main/documentation)
+* Commonalities approved artifacts:  [Artifacts](https://github.com/camaraproject/Commonalities/tree/main/artifacts)

--- a/Commonalities/documentation/README.md
+++ b/Commonalities/documentation/README.md
@@ -1,6 +1,8 @@
 # Commonalities documentation and artifacts
 We have moved to https://github.com/camaraproject/Commonalities
 
+**Please open all new issues and PRs for commonalities in the new repo. All existing open issues have already been moved to the new repo.**
+
 Relevant links:
 * Meeting minutes : [MeetingMinutes](https://github.com/camaraproject/WorkingGroups/tree/main/Commonalities/documentation/MeetingMinutes)
 * Presentations and other supplementary docs : [SupportingDocuments](https://github.com/camaraproject/Commonalities/tree/main/documentation/SupportingDocuments)


### PR DESCRIPTION
Fixes #263 
1. Updated README where documentation links now point to the new comm-repo
2. The README under documentation displays "We have moved (to new repo link)" message and hint about moved issues.