### PR TITLE
Update of README files pointing to the new Commonalities repository

### DIFF
--- a/Commonalities/README.MD
+++ b/Commonalities/README.MD
@@ -5,21 +5,16 @@
 * Location: virtually  
 
 
-## Meetings
-* Meetings are held virtually
-* Schedule: bi-weekly, Thursday, 4 PM CET/CEST (3 PM BST, 15:00 UTC)
-* Meeting link: [MS Teams](https://teams.microsoft.com/l/meetup-join/19%3ameeting_M2E3ZmUxYWUtMDZkNi00YmM1LThiYWMtZjQzNWI0NWQxOGY0%40thread.v2/0?context=%7b%22Tid%22%3a%22bde4dffc-4b60-4cf6-8b04-a5eeb25f5c4f%22%2c%22Oid%22%3a%22a5cb7460-f2b0-42ec-b511-c642f83aa9a3%22%7d)
+## New Repository
+Since July 2023 the work of Commonalities WG takes place in **separate** Github repository: https://github.com/camaraproject/Commonalities
 
-## Results
-Documentation includes:
+For up-to-date contact and communication details, please go to this [new repository](https://github.com/camaraproject/Commonalities).
+
+The current Commonalities documentation includes:
 * Meeting minutes : [MeetingMinutes](https://github.com/camaraproject/Commonalities/tree/main/documentation/MeetingMinutes)
 * Presentations and other supplementary docs : [SupportingDocuments](https://github.com/camaraproject/Commonalities/tree/main/documentation/SupportingDocuments)
 * Commonalities approved deliverables: [Documentation](https://github.com/camaraproject/Commonalities/tree/main/documentation)
 * Commonalities approved artifacts:  [Artifacts](https://github.com/camaraproject/Commonalities/tree/main/artifacts)
-
-## Mailing list
-* To subscribe / unsubscribe to the mailing list of this Working Group please visit <https://lists.camaraproject.org/g/wg-com>.
-* A message to all Working Group members can be sent using <wg-com@lists.camaraproject.org>.
 
 
 

--- a/README.md
+++ b/README.md
@@ -9,5 +9,5 @@
 # CAMARA Working Groups
 Repository for the CAMARA Working Groups:
 * [API backlog](https://github.com/camaraproject/WorkingGroups/tree/main/APIBacklog)
-* [Commonalities](https://github.com/camaraproject/WorkingGroups/tree/main/Commonalities)
+* [Commonalities](https://github.com/camaraproject/Commonalities)
 * [Marketing](https://github.com/camaraproject/WorkingGroups/tree/main/Marketing)


### PR DESCRIPTION
Change of https://github.com/camaraproject/WorkingGroups/blob/main/README.md (point to Com repo, not any more to directory within WorkingGroups
Replace content of https://github.com/camaraproject/WorkingGroups/blob/main/Commonalities/README.MD with pointer to Com repo
